### PR TITLE
Add information on Port Forwarding

### DIFF
--- a/labs/README.md
+++ b/labs/README.md
@@ -22,7 +22,7 @@ This allows you to open Jupyter Notebook in a browser on your local machine whil
 ssh -L 6006:localhost:7373 -J user@seis.bris.ac.uk user@rd-mvb-linuxlab.bristol.ac.uk
 ```
        
-2. Run jupyter notebook on the port mapped to your local machine: 7373
+2. Run Jupyter Notebook on the port mapped to your local machine: 7373
 ```
 /opt/anaconda3-4.4.0/bin/jupyter notebook --no-browser --port 7373
 ```

--- a/labs/README.md
+++ b/labs/README.md
@@ -12,6 +12,18 @@ There are two basic options: remotely logging in to a lab machine or locally ins
 ```
 ssh -X -J youruserid@seis.bris.ac.uk youruserid@rd-mvb-linuxlab.bristol.ac.uk
 ```
+## SSH Port forwarding for Option 2.
+This option will remove latency issues from graphical interface of option 2.
+
+Instead of rendering Jupyter Notebook on the lab machines, you can render it on a browser of your local machine. This will remove most latency issues. To do this you need to forward the port used by Juyper Notebook to a port on your local machine.
+
+Steps below show how to map ports using ssh and to render jupyter notebook on your local machine
+
+1. map a port on your machine to a free port on the lab machines (e.g. 7373)
+       ssh -L 6006:localhost:7373 -J user@seis.bris.ac.uk user@rd-mvb-linuxlab.bristol.ac.uk
+2. Run jupyter notebook on the specified port 7373
+      ```/opt/anaconda3-4.4.0/bin/jupyter notebook --no-browser --port 7373```
+3. open localhost:6006 in a web browser on your local machine.
 
 ## Locally installing Anaconda
 

--- a/labs/README.md
+++ b/labs/README.md
@@ -18,12 +18,14 @@ This option will remove latency issues from the graphical interface of option 2.
 This allows you to open Jupyter Notebook in a browser on your local machine while still running it on a lab machine.
 
 1. Map a free port on your machine (e.g. 6006) to a free port on the lab machine (e.g. 7373)
-
-       ```ssh -L 6006:localhost:7373 -J user@seis.bris.ac.uk user@rd-mvb-linuxlab.bristol.ac.uk```
+```
+ssh -L 6006:localhost:7373 -J user@seis.bris.ac.uk user@rd-mvb-linuxlab.bristol.ac.uk
+```
        
 2. Run jupyter notebook on the port mapped to your local machine: 7373
-
-      ```/opt/anaconda3-4.4.0/bin/jupyter notebook --no-browser --port 7373```
+```
+/opt/anaconda3-4.4.0/bin/jupyter notebook --no-browser --port 7373
+```
       
 3. Open localhost:6006 in a web browser on your local machine and enter the token provided by Jupyter Notebook.
 

--- a/labs/README.md
+++ b/labs/README.md
@@ -13,17 +13,17 @@ There are two basic options: remotely logging in to a lab machine or locally ins
 ssh -X -J youruserid@seis.bris.ac.uk youruserid@rd-mvb-linuxlab.bristol.ac.uk
 ```
 ## SSH Port forwarding for Option 2.
-This option will remove latency issues from graphical interface of option 2.
+This option will remove latency issues from the graphical interface of option 2.
 
-Instead of rendering Jupyter Notebook on the lab machines, you can render it on a browser of your local machine. This will remove most latency issues. To do this you need to forward the port used by Juyper Notebook to a port on your local machine.
+Instead of rendering Jupyter Notebook on the lab machines, you can render it on a browser of your local machine. This will remove most latency issues. To do this you need to forward the port used by Juypter Notebook to a port on your local machine.
 
-Steps below show how to map ports using ssh and to render jupyter notebook on your local machine
+Steps below show how to map ports using ssh and to render Juypter Notebook on your local machine:
 
-1. map a port on your machine to a free port on the lab machines (e.g. 7373)
-       ssh -L 6006:localhost:7373 -J user@seis.bris.ac.uk user@rd-mvb-linuxlab.bristol.ac.uk
+1. Map a port on your machine to a free port on the lab machines (e.g. 7373)
+       ```ssh -L 6006:localhost:7373 -J user@seis.bris.ac.uk user@rd-mvb-linuxlab.bristol.ac.uk```
 2. Run jupyter notebook on the specified port 7373
       ```/opt/anaconda3-4.4.0/bin/jupyter notebook --no-browser --port 7373```
-3. open localhost:6006 in a web browser on your local machine.
+3. Open localhost:6006 in a web browser on your local machine and enter the token provided by Jupyter Notebook.
 
 ## Locally installing Anaconda
 

--- a/labs/README.md
+++ b/labs/README.md
@@ -15,14 +15,16 @@ ssh -X -J youruserid@seis.bris.ac.uk youruserid@rd-mvb-linuxlab.bristol.ac.uk
 ## SSH Port forwarding for Option 2
 This option will remove latency issues from the graphical interface of option 2.
 
-Instead of rendering Jupyter Notebook on the lab machines, you can render it on a browser of your local machine. This will remove most latency issues. To do this you need to forward the port used by Juypter Notebook to a port on your local machine.
+This allows you to open Jupyter Notebook in a browser on your local machine while still running it on a lab machine.
 
-Steps below show how to map ports using ssh and to render Juypter Notebook on your local machine:
+1. Map a free port on your machine (e.g. 6006) to a free port on the lab machine (e.g. 7373)
 
-1. Map a port on your machine to a free port on the lab machines (e.g. 7373)
        ```ssh -L 6006:localhost:7373 -J user@seis.bris.ac.uk user@rd-mvb-linuxlab.bristol.ac.uk```
-2. Run jupyter notebook on the specified port 7373
+       
+2. Run jupyter notebook on the port mapped to your local machine: 7373
+
       ```/opt/anaconda3-4.4.0/bin/jupyter notebook --no-browser --port 7373```
+      
 3. Open localhost:6006 in a web browser on your local machine and enter the token provided by Jupyter Notebook.
 
 ## Locally installing Anaconda

--- a/labs/README.md
+++ b/labs/README.md
@@ -12,7 +12,7 @@ There are two basic options: remotely logging in to a lab machine or locally ins
 ```
 ssh -X -J youruserid@seis.bris.ac.uk youruserid@rd-mvb-linuxlab.bristol.ac.uk
 ```
-## SSH Port forwarding for Option 2.
+## SSH Port forwarding for Option 2
 This option will remove latency issues from the graphical interface of option 2.
 
 Instead of rendering Jupyter Notebook on the lab machines, you can render it on a browser of your local machine. This will remove most latency issues. To do this you need to forward the port used by Juypter Notebook to a port on your local machine.


### PR DESCRIPTION
Adding instructions to forward a lab machine port to the students local machine to access Jupyter Notebook from their own browser but still running it on the lab machine.